### PR TITLE
Don't serialize JSON columns as strings when archiving

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
   postgres:
     image: postgres:9.6.3
     ports:
-      - 5432:5432
+      - 5433:5432
     volumes:
       - pg_data:/var/lib/postgresql/data

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,5 @@
-import datetime
-
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, UniqueConstraint
+from sqlalchemy import Boolean, Column, DateTime, func, Integer, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.declarative import declarative_base
 
 from savage.models import SavageLogMixin, SavageModelMixin
@@ -17,7 +16,8 @@ class UserTable(SavageModelMixin, Base):
     col2 = Column(Integer)
     col3 = Column(Boolean)
     col4 = Column('other_name', Integer)
-    col5 = Column(DateTime, default=datetime.datetime.utcnow)
+    col5 = Column(DateTime, server_default=func.now())
+    jsonb_col = Column(JSONB, default=dict)
 
 
 class ArchiveTable(SavageLogMixin, Base):
@@ -61,4 +61,5 @@ class UnarchivedTable(Base):
     id = Column(Integer, primary_key=True)
     name = Column(String)
     _private_attr = Column('private_attr', Integer)
-    created_at = Column(DateTime, default=datetime.datetime.utcnow)
+    created_at = Column(DateTime, default=func.now())
+    jsonb_col = Column(JSONB, default=dict)

--- a/tests/test_inserts.py
+++ b/tests/test_inserts.py
@@ -33,3 +33,13 @@ def test_insert_new_product_with_user(session, p1_dict, p1):
 
     verify_row(p1_dict, version, session)
     verify_archive(p1_dict, version, session, user='test_user')
+
+
+def test_insert_new_product_with_json(session, p1_dict, p1):
+    json_dict = {'foo': 'bar'}
+    p1.jsonb_col = json_dict.copy()
+    version = add_and_return_version(p1, session)
+
+    expected = dict(jsonb_col=json_dict, **p1_dict)
+    verify_row(expected, version, session)
+    verify_archive(expected, version, session)

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -115,6 +115,19 @@ def test_product_update_with_user(session, p1_dict, p1):
     verify_archive(updated_dict, updated_version, session, user='test_user2')
 
 
+def test_product_update_with_json(session, p1_dict, p1):
+    version = add_and_return_version(p1, session)
+
+    json_dict = {'foo': 'bar'}
+    p1.jsonb_col = json_dict.copy()
+    updated_version = add_and_return_version(p1, session)
+    updated_dict = dict(p1_dict, jsonb_col=json_dict)
+
+    verify_row(updated_dict, updated_version, session)
+    verify_archive(p1_dict, version, session)
+    verify_archive(updated_dict, updated_version, session)
+
+
 def test_concurrent_product_updates(engine_1, engine_2, user_table, p1_dict, p1):
     """
     Assert that if two separate sessions try to update a product row,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,10 @@ def saved_model(session):
     return model
 
 
+def assert_expected_attr_value(row, attr, expected_value, **kwargs):
+    assert utils.get_column_attribute(row, attr, **kwargs) == expected_value
+
+
 def test_result_to_dict(session, saved_model):
     res = session.execute(select([UnarchivedTable]))
     dicts = utils.result_to_dict(res)
@@ -32,18 +36,18 @@ def test_result_to_dict(session, saved_model):
 
 
 def test_get_column_attribute(saved_model, dialect):
-    assert utils.get_column_attribute(saved_model, 'name', dialect=dialect) == 'foo'
+    assert_expected_attr_value(saved_model, 'name', 'foo', dialect=dialect)
 
 
 def test_get_column_attribute_dirty(saved_model, dialect):
     saved_model.name = 'bar'
-    assert utils.get_column_attribute(saved_model, 'name', use_dirty=False, dialect=dialect) == 'foo'
+    assert_expected_attr_value(saved_model, 'name', 'foo', use_dirty=False, dialect=dialect)
 
 
 def test_get_column_attribute_json(saved_model, dialect):
     json_dict = {'foo': 'bar'}
     saved_model.jsonb_col = json_dict.copy()
-    assert utils.get_column_attribute(saved_model, 'jsonb_col', dialect=dialect) == json_dict
+    assert_expected_attr_value(saved_model, 'jsonb_col', json_dict, dialect=dialect)
 
 
 def test_get_column_keys():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,30 +25,37 @@ def test_result_to_dict(session, saved_model):
         'id': saved_model.id,
         'name': 'foo',
         'private_attr': None,
-        'created_at': saved_model.created_at
+        'created_at': saved_model.created_at,
+        'jsonb_col': {},
     }
     assert dicts == [expected_dict]
 
 
-def test_get_column_attribute(saved_model):
-    assert utils.get_column_attribute(saved_model, 'name') == 'foo'
+def test_get_column_attribute(saved_model, dialect):
+    assert utils.get_column_attribute(saved_model, 'name', dialect=dialect) == 'foo'
 
 
-def test_get_column_attribute_dirty(session, saved_model):
+def test_get_column_attribute_dirty(saved_model, dialect):
     saved_model.name = 'bar'
-    assert utils.get_column_attribute(saved_model, 'name', use_dirty=False) == 'foo'
+    assert utils.get_column_attribute(saved_model, 'name', use_dirty=False, dialect=dialect) == 'foo'
+
+
+def test_get_column_attribute_json(saved_model, dialect):
+    json_dict = {'foo': 'bar'}
+    saved_model.jsonb_col = json_dict.copy()
+    assert utils.get_column_attribute(saved_model, 'jsonb_col', dialect=dialect) == json_dict
 
 
 def test_get_column_keys():
     col_keys_gen = utils.get_column_keys(UnarchivedTable)
     assert isinstance(col_keys_gen, types.GeneratorType)
-    assert sorted(col_keys_gen) == ['_private_attr', 'created_at', 'id', 'name']
+    assert sorted(col_keys_gen) == ['_private_attr', 'created_at', 'id', 'jsonb_col', 'name']
 
 
 def test_get_column_names():
     col_keys_gen = utils.get_column_names(UnarchivedTable)
     assert isinstance(col_keys_gen, types.GeneratorType)
-    assert sorted(col_keys_gen) == ['created_at', 'id', 'name', 'private_attr']
+    assert sorted(col_keys_gen) == ['created_at', 'id', 'jsonb_col', 'name', 'private_attr']
 
 
 def test_get_column_keys_and_names():
@@ -58,7 +65,8 @@ def test_get_column_keys_and_names():
         ('_private_attr', 'private_attr'),
         ('created_at', 'created_at'),
         ('id', 'id'),
-        ('name', 'name')
+        ('jsonb_col', 'jsonb_col'),
+        ('name', 'name'),
     ]
 
 


### PR DESCRIPTION
Fixes #8 

This PR patches `utils.get_column_attribute` to skip bind processing for columns with an underlying JSON dialect implementation. Before this change, `get_column_attribute()` would return the serialized string version of JSON column data. This prevents end users from leveraging the GIN index on `SavageLogMixin.data` to query against nested JSON archive data.

---

Changes:
  * Patch `get_column_attribute` to skip bind processing for JSON column types
  * Added/updated tests to validate new functionality