### PR TITLE
Broader handling of JSON columns

### DIFF
--- a/src/savage/utils.py
+++ b/src/savage/utils.py
@@ -4,7 +4,6 @@ from functools import partial
 
 import simplejson as json
 from sqlalchemy import inspect, UniqueConstraint
-from sqlalchemy.dialects.postgresql import JSON, JSONB
 from sqlalchemy.engine.reflection import Inspector
 
 
@@ -41,7 +40,7 @@ def get_column_attribute(row, col_name, use_dirty=True, dialect=None):
         # but we want to preserve the JSON dictionaries when archiving row data.
         # Original issue: https://github.com/NerdWalletOSS/savage/issues/8
         dialect_impl = column_type.dialect_impl(dialect)
-        if not isinstance(dialect_impl, (JSON, JSONB)):
+        if not dialect_impl.compile(dialect) in {'JSON', 'JSONB'}:
             bind_processor = column_type.bind_processor(dialect)
     bind_processor = bind_processor or identity
     current_value = bind_processor(getattr(row, col_name))

--- a/tests/db_utils.py
+++ b/tests/db_utils.py
@@ -5,7 +5,7 @@ from psycopg2 import connect
 from sqlalchemy.orm import sessionmaker
 
 PG_CONFIG = dict(user='postgres', password='', host='localhost', port=5433)
-CI_PG_CONFIG = dict()
+CI_PG_CONFIG = dict(PG_CONFIG, port=5432)
 
 MASTER_DATABASE = 'postgres'
 TEST_DATABASE = 'savage_test'

--- a/tests/db_utils.py
+++ b/tests/db_utils.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from psycopg2 import connect
 from sqlalchemy.orm import sessionmaker
 
-PG_CONFIG = dict(user='postgres', password='', host='localhost', port=5432)
+PG_CONFIG = dict(user='postgres', password='', host='localhost', port=5433)
 CI_PG_CONFIG = dict()
 
 MASTER_DATABASE = 'postgres'

--- a/tests/db_utils.py
+++ b/tests/db_utils.py
@@ -14,7 +14,7 @@ Session = sessionmaker()
 
 
 def get_pg_config():
-    if os.environ.get('BUILD_NUMBER') is not None:
+    if os.environ.get('CI') is not None:
         # Use CI test database
         return CI_PG_CONFIG
     return PG_CONFIG

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,10 +1,18 @@
-from sqlalchemy import Boolean, Column, DateTime, func, Integer, String, UniqueConstraint
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import Boolean, Column, DateTime, func, Integer, String, types, UniqueConstraint
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.declarative import declarative_base
 
 from savage.models import SavageLogMixin, SavageModelMixin
 
 Base = declarative_base()
+
+
+class JSONWrapper(types.TypeDecorator):
+    """Wrapper class to designate JSONB columns tied to dynamic schemas"""
+    impl = postgresql.JSONB
+
+    def compile(self, dialect=None):
+        return super(JSONWrapper, self).compile(postgresql.dialect())
 
 
 class UserTable(SavageModelMixin, Base):
@@ -17,7 +25,7 @@ class UserTable(SavageModelMixin, Base):
     col3 = Column(Boolean)
     col4 = Column('other_name', Integer)
     col5 = Column(DateTime, server_default=func.now())
-    jsonb_col = Column(JSONB, default=dict)
+    jsonb_col = Column(postgresql.JSONB, default=dict)
 
 
 class ArchiveTable(SavageLogMixin, Base):
@@ -62,4 +70,4 @@ class UnarchivedTable(Base):
     name = Column(String)
     _private_attr = Column('private_attr', Integer)
     created_at = Column(DateTime, default=func.now())
-    jsonb_col = Column(JSONB, default=dict)
+    jsonb_col = Column(JSONWrapper, default=dict)


### PR DESCRIPTION
This updates `utils.get_column_attribute` to skip bind processing of custom JSON types (in addition to standard JSON/JSONB), and adds a corresponding test. Additionally, this fixes an issue with test DB configuration in CI.