### PR TITLE
Smarter patching of bind processors for JSON/JSONB column types

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -1,4 +1,16 @@
-from sqlalchemy import Boolean, Column, DateTime, func, Integer, String, types, UniqueConstraint
+from functools import partial
+
+import simplejson as json
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    func,
+    Integer,
+    String,
+    TypeDecorator,
+    UniqueConstraint,
+)
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.declarative import declarative_base
 
@@ -7,12 +19,47 @@ from savage.models import SavageLogMixin, SavageModelMixin
 Base = declarative_base()
 
 
-class JSONWrapper(types.TypeDecorator):
-    """Wrapper class to designate JSONB columns tied to dynamic schemas"""
+class JSONWrapper(object):
+    def __init__(self, json_dict):
+        self.json_dict = json_dict
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.json_dict == other.json_dict
+        return False
+
+    @classmethod
+    def empty(cls):
+        return cls({})
+
+
+class DecoratedJSONB(TypeDecorator):
     impl = postgresql.JSONB
 
     def compile(self, dialect=None):
-        return super(JSONWrapper, self).compile(postgresql.dialect())
+        return super(DecoratedJSONB, self).compile(postgresql.dialect())
+
+
+class SortedJSON(postgresql.JSON):
+    def bind_processor(self, dialect):
+        return partial(json.dumps, sort_keys=True)
+
+
+class WrappedJSON(TypeDecorator):
+    impl = postgresql.JSONB
+
+    def compile(self, dialect=None):
+        return super(WrappedJSON, self).compile(postgresql.dialect())
+
+    def process_bind_param(self, value, dialect):
+        return value.json_dict
+
+    def process_result_value(self, value, dialect):
+        return JSONWrapper(value)
+
+    @property
+    def python_type(self):
+        return JSONWrapper
 
 
 class UserTable(SavageModelMixin, Base):
@@ -70,4 +117,6 @@ class UnarchivedTable(Base):
     name = Column(String)
     _private_attr = Column('private_attr', Integer)
     created_at = Column(DateTime, default=func.now())
-    jsonb_col = Column(JSONWrapper, default=dict)
+    decorated_jsonb_col = Column(DecoratedJSONB, default=dict)
+    sorted_json_col = Column(SortedJSON, default=dict)
+    wrapped_jsonb_col = Column(WrappedJSON, default=JSONWrapper.empty)


### PR DESCRIPTION
Fixes #8 

This PR updates `utils.get_column_attribute` to return dictionaries instead of serialized JSON strings for *any* JSON/JSONB column type.

The previous fix skipped bind processing for JSON/JSONB columns, but this breaks for custom JSON/JSONB column types that add their own bind processing. In order to work around this, a new utils method (`get_bind_processor`) was added:

  * For non-JSON/JSONB column types, simply return the type's bind processor
  * For bare JSON/JSONB types, skip bind processing completely
  * For decorated JSON/JSONB types, run custom bind processing (if any) but skip JSON serialization
  * For all other JSON/JSONB types, fall back to deserializing the JSON string result from bind processing

This avoids the unnecessary overhead of JSON dump/load whenever possible, while supporting the full array of possible JSON/JSONB custom data types.

